### PR TITLE
Refactored so that rpc client doesn't rely on zenodb package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+go:
+- 1.7.5
+install:
+- cd /tmp && curl -L https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz -o glide.tar.gz && tar -xf glide.tar.gz && mkdir -p $GOPATH/bin && mv linux-amd64/glide $GOPATH/bin/ && cd -
+- go get golang.org/x/tools/cmd/cover
+- go get -v github.com/axw/gocov/gocov
+- go get -v github.com/mattn/goveralls
+script:
+- glide install
+- ./test.sh
+# after_success:
+# - GOPATH=`pwd`:$GOPATH $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/common/common.go
+++ b/common/common.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"github.com/getlantern/bytemap"
+	"github.com/getlantern/wal"
+	"github.com/getlantern/zenodb/encoding"
+	"time"
+)
+
+type Partition struct {
+	Keys   []string
+	Tables []*PartitionTable
+}
+
+type PartitionTable struct {
+	Name   string
+	Offset wal.Offset
+}
+
+type Follow struct {
+	Stream          string
+	EarliestOffset  wal.Offset
+	PartitionNumber int
+	Partitions      map[string]*Partition
+}
+
+type QueryRemote func(sqlString string, includeMemStore bool, isSubQuery bool, subQueryResults [][]interface{}, onValue func(bytemap.ByteMap, []encoding.Sequence)) (hasReadResult bool, err error)
+
+type QueryMetaData struct {
+	FieldNames []string
+	AsOf       time.Time
+	Until      time.Time
+	Resolution time.Duration
+	Plan       string
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 333282a49301e9e5ce99ad315361d3ca3ea05c71ce985cc5d3b4c4bbd3712d8b
-updated: 2016-12-12T08:27:03.770030888-06:00
+hash: 8eee0dead8f76fef47fc3dba98540f6f13efac2bfaf25d9df9b4eb55448d4b15
+updated: 2017-02-06T06:26:32.24436761-08:00
 imports:
 - name: github.com/chzyer/readline
   version: c914be64f07d9998f52bf0d598ec26d457168c0f
@@ -16,7 +16,7 @@ imports:
 - name: github.com/getlantern/byteexec
   version: 2e21fedeb225921a8dc40321cbd114ffd0a302f3
 - name: github.com/getlantern/bytemap
-  version: ce04d277429812f5e68b4749471df0181996df04
+  version: ab0ac5e9eea2aaafe50159a9d4b0f046cabce133
 - name: github.com/getlantern/context
   version: 624d99b1798d7c5375ea1d3ca4c5b04d58f7c775
 - name: github.com/getlantern/errors
@@ -24,7 +24,7 @@ imports:
 - name: github.com/getlantern/filepersist
   version: c5f0cd24e7991579ba6f5f1bd20a1ad2c9f06cd4
 - name: github.com/getlantern/goexpr
-  version: 30a6b8887b0348a75f4096ac9dd0fd9e21839403
+  version: 004965a39a9276306090906eeff463a5cb5bc997
   subpackages:
   - geo
   - isp
@@ -54,7 +54,7 @@ imports:
 - name: github.com/getlantern/vtime
   version: dc1e573cf9918131774034baa8eade77ef901ea3
 - name: github.com/getlantern/wal
-  version: 4f9fc7636ad0f027ecb5b96a1d160880c34b77c9
+  version: 65cc618aae913a62438160199f5fd6495083182c
 - name: github.com/getlantern/yaml
   version: 97d86b60f57eeca9d70c02763ed2565bafc17585
 - name: github.com/golang/protobuf
@@ -67,6 +67,8 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/gorilla/securecookie
+  version: fa5329f913702981df43dcb2a380bac429c810b5
 - name: github.com/hashicorp/golang-lru
   version: 0a025b7e63adc15a622f29b0b2c4c3848243bbf6
   subpackages:
@@ -81,6 +83,8 @@ imports:
   version: 4e1c5567d7c2dd59fa4c7c83d34c2f3528b025d6
 - name: github.com/oxtoacart/emsort
   version: e467347e335434365584bc76ce22b8d23190da6e
+- name: github.com/retailnext/hllpp
+  version: 38a7bb71b483e855d35010808143beaf05b67f9d
 - name: github.com/rickar/props
   version: c68a002e87c1dca1be6eebaf289dfe56db65c87e
 - name: github.com/spaolacci/murmur3
@@ -153,7 +157,7 @@ imports:
   - internal/pool
   - internal/proto
 - name: gopkg.in/vmihailenco/msgpack.v2
-  version: 94af6ea04d2da6a09d6914ca79b8fb94f3acbba4
+  version: a1382b1ce0c749733b814157c245e02cc1f41076
   subpackages:
   - codes
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,6 +16,7 @@ import:
 - package: github.com/getlantern/sqlparser
 - package: github.com/getlantern/vtime
 - package: github.com/getlantern/yaml
+- package: github.com/getlantern/wal
 - package: github.com/golang/snappy
 - package: github.com/gorilla/mux
 - package: github.com/jmcvetta/randutil

--- a/query.go
+++ b/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/getlantern/bytemap"
+	"github.com/getlantern/zenodb/common"
 	"github.com/getlantern/zenodb/core"
 	"github.com/getlantern/zenodb/encoding"
 	"github.com/getlantern/zenodb/planner"
@@ -43,16 +44,8 @@ func (db *DB) getQueryable(table string, includedFields func(tableFields core.Fi
 	return &queryable{t, includedFields(t.Fields), asOf, until, includeMemStore}
 }
 
-type QueryMetaData struct {
-	FieldNames []string
-	AsOf       time.Time
-	Until      time.Time
-	Resolution time.Duration
-	Plan       string
-}
-
-func MetaDataFor(source core.FlatRowSource) *QueryMetaData {
-	return &QueryMetaData{
+func MetaDataFor(source core.FlatRowSource) *common.QueryMetaData {
+	return &common.QueryMetaData{
 		FieldNames: source.GetFields().Names(),
 		AsOf:       source.GetAsOf(),
 		Until:      source.GetUntil(),

--- a/rpc/server/rpc_test.go
+++ b/rpc/server/rpc_test.go
@@ -1,4 +1,4 @@
-package rpc
+package rpcserver
 
 import (
 	"context"
@@ -9,9 +9,10 @@ import (
 
 	"github.com/getlantern/bytemap"
 	"github.com/getlantern/wal"
-	"github.com/getlantern/zenodb"
+	"github.com/getlantern/zenodb/common"
 	"github.com/getlantern/zenodb/core"
 	"github.com/getlantern/zenodb/planner"
+	"github.com/getlantern/zenodb/rpc"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,14 +25,14 @@ func TestInsert(t *testing.T) {
 
 	db := &mockDB{}
 	go func() {
-		err = Serve(db, l, &ServerOpts{
+		err = Serve(db, l, &Opts{
 			Password: "password",
 		})
 		assert.NoError(t, err)
 	}()
 	time.Sleep(1 * time.Second)
 
-	client, err := Dial(l.Addr().String(), &ClientOpts{
+	client, err := rpc.Dial(l.Addr().String(), &rpc.ClientOpts{
 		Password: "password",
 		Dialer: func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("tcp", addr, timeout)
@@ -96,7 +97,7 @@ func (db *mockDB) Query(sqlString string, isSubQuery bool, subQueryResults [][]i
 	return nil, nil
 }
 
-func (db *mockDB) Follow(f *zenodb.Follow, cb func([]byte, wal.Offset) error) error {
+func (db *mockDB) Follow(f *common.Follow, cb func([]byte, wal.Offset) error) error {
 	return nil
 }
 

--- a/rpc/server/rpc_test.go
+++ b/rpc/server/rpc_test.go
@@ -25,10 +25,9 @@ func TestInsert(t *testing.T) {
 
 	db := &mockDB{}
 	go func() {
-		err = Serve(db, l, &Opts{
+		Serve(db, l, &Opts{
 			Password: "password",
 		})
-		assert.NoError(t, err)
 	}()
 	time.Sleep(1 * time.Second)
 

--- a/rpc/snappyconn.go
+++ b/rpc/snappyconn.go
@@ -12,11 +12,11 @@ func snappyDialer(d func(string, time.Duration) (net.Conn, error)) func(addr str
 	}
 }
 
-type snappyListener struct {
+type SnappyListener struct {
 	net.Listener
 }
 
-func (sl *snappyListener) Accept() (net.Conn, error) {
+func (sl *SnappyListener) Accept() (net.Conn, error) {
 	return snappyWrap(sl.Listener.Accept())
 }
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env sh
+find . -type d | grep -v vendor | grep -v ".git" | xargs -I{} echo "(cd {}; go test -race) &&" | paste -s -d" " - | sed 's/$/ true/' | /usr/bin/env sh
+exit $?

--- a/zeno-cli/zeno-cli.go
+++ b/zeno-cli/zeno-cli.go
@@ -17,7 +17,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/getlantern/appdir"
 	"github.com/getlantern/golog"
-	"github.com/getlantern/zenodb"
+	"github.com/getlantern/zenodb/common"
 	"github.com/getlantern/zenodb/core"
 	"github.com/getlantern/zenodb/encoding"
 	"github.com/getlantern/zenodb/rpc"
@@ -145,7 +145,7 @@ func query(stdout io.Writer, stderr io.Writer, client rpc.Client, sql string, cs
 	return dumpPlainText(stdout, sql, md, iterate)
 }
 
-func dumpPlainText(stdout io.Writer, sql string, md *zenodb.QueryMetaData, iterate func(onRow core.OnFlatRow) error) error {
+func dumpPlainText(stdout io.Writer, sql string, md *common.QueryMetaData, iterate func(onRow core.OnFlatRow) error) error {
 	printQueryStats(os.Stderr, md)
 
 	// Read all rows into list and collect unique dimensions
@@ -336,7 +336,7 @@ func dumpPlainText(stdout io.Writer, sql string, md *zenodb.QueryMetaData, itera
 	return nil
 }
 
-func dumpCSV(stdout io.Writer, md *zenodb.QueryMetaData, iterate func(onRow core.OnFlatRow) error) error {
+func dumpCSV(stdout io.Writer, md *common.QueryMetaData, iterate func(onRow core.OnFlatRow) error) error {
 	printQueryStats(os.Stderr, md)
 
 	w := csv.NewWriter(stdout)
@@ -471,7 +471,7 @@ func nilToDash(val interface{}) interface{} {
 	return val
 }
 
-func numFieldsFor(md *zenodb.QueryMetaData) int {
+func numFieldsFor(md *common.QueryMetaData) int {
 	numFields := len(md.FieldNames)
 	// if result.IsCrosstab {
 	// 	for _, populated := range result.PopulatedColumns {
@@ -483,7 +483,7 @@ func numFieldsFor(md *zenodb.QueryMetaData) int {
 	return numFields
 }
 
-func printQueryStats(stderr io.Writer, md *zenodb.QueryMetaData) {
+func printQueryStats(stderr io.Writer, md *common.QueryMetaData) {
 	// TODO: maybe restore additional stats?
 	if !*queryStats {
 		return

--- a/zeno/zeno.go
+++ b/zeno/zeno.go
@@ -18,8 +18,10 @@ import (
 	"github.com/getlantern/tlsdefaults"
 	"github.com/getlantern/wal"
 	"github.com/getlantern/zenodb"
+	"github.com/getlantern/zenodb/common"
 	"github.com/getlantern/zenodb/planner"
 	"github.com/getlantern/zenodb/rpc"
+	"github.com/getlantern/zenodb/rpc/server"
 	"github.com/getlantern/zenodb/web"
 	"github.com/gorilla/mux"
 	"github.com/vharitonsky/iniflags"
@@ -110,7 +112,7 @@ func main() {
 	}
 
 	clientSessionCache := tls.NewLRUClientSessionCache(10000)
-	var follow func(f *zenodb.Follow, cb func(data []byte, newOffset wal.Offset) error)
+	var follow func(f *common.Follow, cb func(data []byte, newOffset wal.Offset) error)
 	var registerQueryHandler func(partition int, query planner.QueryClusterFN)
 	if *capture != "" {
 		host, _, _ := net.SplitHostPort(*capture)
@@ -143,7 +145,7 @@ func main() {
 		}
 
 		log.Debugf("Capturing data from %v", *capture)
-		follow = func(f *zenodb.Follow, insert func(data []byte, newOffset wal.Offset) error) {
+		follow = func(f *common.Follow, insert func(data []byte, newOffset wal.Offset) error) {
 			minWait := 1 * time.Second
 			maxWait := 1 * time.Minute
 			wait := minWait
@@ -301,7 +303,7 @@ func main() {
 }
 
 func serveRPC(db *zenodb.DB, l net.Listener) {
-	err := rpc.Serve(db, l, &rpc.ServerOpts{
+	err := rpcserver.Serve(db, l, &rpcserver.Opts{
 		Password: *password,
 	})
 	if err != nil {

--- a/zenodb.go
+++ b/zenodb.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getlantern/golog"
 	"github.com/getlantern/vtime"
 	"github.com/getlantern/wal"
+	"github.com/getlantern/zenodb/common"
 	"github.com/getlantern/zenodb/core"
 	"github.com/getlantern/zenodb/planner"
 	"github.com/getlantern/zenodb/sql"
@@ -88,7 +89,7 @@ type DBOpts struct {
 	MaxFollowAge time.Duration
 	// Follow is a function that allows a follower to request following a stream
 	// from a passthrough node.
-	Follow                     func(f *Follow, cb func(data []byte, newOffset wal.Offset) error)
+	Follow                     func(f *common.Follow, cb func(data []byte, newOffset wal.Offset) error)
 	RegisterRemoteQueryHandler func(partition int, query planner.QueryClusterFN)
 }
 

--- a/zenodb_test.go
+++ b/zenodb_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/getlantern/wal"
+	"github.com/getlantern/zenodb/common"
 	"github.com/getlantern/zenodb/core"
 	"github.com/getlantern/zenodb/encoding"
 	. "github.com/getlantern/zenodb/expr"
@@ -81,7 +82,7 @@ func doTestCluster(t *testing.T, partitionBy []string) {
 				NumPartitions:  numPartitions,
 				Partition:      part,
 				MaxMemoryRatio: 0.00001,
-				Follow: func(f *Follow, cb func(data []byte, newOffset wal.Offset) error) {
+				Follow: func(f *common.Follow, cb func(data []byte, newOffset wal.Offset) error) {
 					leader.Follow(f, cb)
 				},
 				RegisterRemoteQueryHandler: func(partition int, query planner.QueryClusterFN) {


### PR DESCRIPTION
This refactoring removes the dependency of the rpc client on the zenodb package in order to fix getlantern/lantern-internal#670