### PR TITLE
use testify master because older version creates upstream build issues

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -138,8 +138,8 @@
   name = "github.com/spaolacci/murmur3"
 
 [[constraint]]
+  branch = "master"
   name = "github.com/stretchr/testify"
-  version = "1.1.4"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
See https://app.wercker.com/getlantern/http-proxy-lantern/runs/build/5b613c1104dfe20010e440b0?step=5b613c2da20e52000715053c