### PR TITLE
Support inserts with array values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/getlantern/appdir v0.0.0-20180320102544-7c0f9d241ea7
 	github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4 // indirect
-	github.com/getlantern/bytemap v0.0.0-20180417025909-c7bf952233bc
+	github.com/getlantern/bytemap v0.0.0-20190911140348-f17f27076bf9
 	github.com/getlantern/elevate v0.0.0-20180207094634-c2e2e4901072 // indirect
 	github.com/getlantern/errors v0.0.0-20190325191628-abdb3e3e36f7
 	github.com/getlantern/filepersist v0.0.0-20160317154340-c5f0cd24e799 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,10 @@ github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4 h1:Nqmy8i81dzo
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
 github.com/getlantern/bytemap v0.0.0-20180417025909-c7bf952233bc h1:TVT95IccIoeFnFPD169fak0Uxr0NSwgcqVI+oLPDdNo=
 github.com/getlantern/bytemap v0.0.0-20180417025909-c7bf952233bc/go.mod h1:DFhUkF3XKDQgnCNVn203TVnRxy4oUnIIMClem8MQxKE=
+github.com/getlantern/bytemap v0.0.0-20190911134738-859d2dbc7b81 h1:hTkKgOzif6TE6cnrrqvjF0DgFzk/Zw9iwGLo3O88KGA=
+github.com/getlantern/bytemap v0.0.0-20190911134738-859d2dbc7b81/go.mod h1:DFhUkF3XKDQgnCNVn203TVnRxy4oUnIIMClem8MQxKE=
+github.com/getlantern/bytemap v0.0.0-20190911140348-f17f27076bf9 h1:xpu/mmrhhkINppMPqVLrVkuK7tT7atRthPfzmzdJQr0=
+github.com/getlantern/bytemap v0.0.0-20190911140348-f17f27076bf9/go.mod h1:DFhUkF3XKDQgnCNVn203TVnRxy4oUnIIMClem8MQxKE=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 h1:NRUJuo3v3WGC/g5YiyF790gut6oQr5f3FBI88Wv0dx4=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/elevate v0.0.0-20180207094634-c2e2e4901072 h1:Sxd/u3rnHYAqXzpRXjOA7DPyRKYzcivMRBKtOhsRwW8=

--- a/web/insert.go
+++ b/web/insert.go
@@ -21,7 +21,7 @@ const (
 type Point struct {
 	Ts   time.Time              `json:"ts,omitempty"`
 	Dims map[string]interface{} `json:"dims,omitempty"`
-	Vals map[string]float64     `json:"vals,omitempty"`
+	Vals map[string]interface{} `json:"vals,omitempty"`
 }
 
 func (h *handler) insert(resp http.ResponseWriter, req *http.Request) {

--- a/zenodb_test.go
+++ b/zenodb_test.go
@@ -187,7 +187,7 @@ view_a:
 			"b":  false,
 			"md": "glub",
 		},
-		map[string]float64{
+		map[string]interface{}{
 			"i":  1,
 			"ii": 2,
 			"iv": 10,
@@ -195,19 +195,37 @@ view_a:
 	shuffleFields()
 
 	// Add a bunch of data for percentile calculation
-	for i := float64(1); i <= 100; i++ {
-		db.Insert("inbound",
-			now,
-			map[string]interface{}{
-				"r":  "A",
-				"u":  1,
-				"b":  false,
-				"md": "glub",
-			},
-			map[string]float64{
-				"p": i,
-			})
+	pi := make([]int, 0)
+	pf := make([]float64, 0)
+	for i := 0; i <= 100; i++ {
+		if i%2 == 0 {
+			pi = append(pi, i)
+		} else {
+			pf = append(pf, float64(i))
+		}
 	}
+	db.Insert("inbound",
+		now,
+		map[string]interface{}{
+			"r":  "A",
+			"u":  1,
+			"b":  false,
+			"md": "glub",
+		},
+		map[string]interface{}{
+			"p": pi,
+		})
+	db.Insert("inbound",
+		now,
+		map[string]interface{}{
+			"r":  "A",
+			"u":  1,
+			"b":  false,
+			"md": "glub",
+		},
+		map[string]interface{}{
+			"p": pf,
+		})
 
 	// This should get excluded by the filter
 	db.Insert("inbound",
@@ -218,11 +236,27 @@ view_a:
 			"b":  false,
 			"md": "glub",
 		},
-		map[string]float64{
+		map[string]interface{}{
 			"i":  1,
 			"ii": 2,
 			"iv": 10,
 		})
+
+	// This should be ignored since it contains only invalid fields
+	db.Insert("inbound",
+		now.Add(randBelowResolution()),
+		map[string]interface{}{
+			"r":  "B",
+			"u":  1,
+			"b":  false,
+			"md": "glub",
+		},
+		map[string]interface{}{
+			"i":  "blah",
+			"ii": true,
+			"iv": float32(4),
+		})
+
 	shuffleFields()
 
 	db.Insert("inbound",
@@ -233,7 +267,7 @@ view_a:
 			"b":  false,
 			"md": "glub",
 		},
-		map[string]float64{
+		map[string]interface{}{
 			"i":  10,
 			"ii": 20,
 			"iv": 20,
@@ -250,7 +284,7 @@ view_a:
 			"b":  false,
 			"md": "glub",
 		},
-		map[string]float64{
+		map[string]interface{}{
 			"i":  111,
 			"ii": 222,
 			"iv": 30,
@@ -265,7 +299,7 @@ view_a:
 			"b":  false,
 			"md": "glub",
 		},
-		map[string]float64{
+		map[string]interface{}{
 			"i":  31,
 			"ii": 42,
 			"z":  53,
@@ -280,7 +314,7 @@ view_a:
 			"b":  true,
 			"md": "glub",
 		},
-		map[string]float64{
+		map[string]interface{}{
 			"i":  30000,
 			"ii": 40000,
 		})
@@ -299,7 +333,7 @@ view_a:
 			"b":  false,
 			"md": "glub",
 		},
-		map[string]float64{
+		map[string]interface{}{
 			"i":  500,
 			"ii": 600,
 			"z":  700,


### PR DESCRIPTION
This will allow clients to fairly efficiently report discrete values which we can then store in PERCENTILE fields on the server side.

Ideally I would store the array values themselves in the WAL, but the assumption that values stored there are scalar floats is baked into too much of the ZenoDB code for that to be feasible.