### PR TITLE
Fixed optimized (wrapped) percentiles

### DIFF
--- a/expr/percentile_optimized.go
+++ b/expr/percentile_optimized.go
@@ -2,74 +2,40 @@ package expr
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/getlantern/goexpr"
 	"github.com/getlantern/msgpack"
 )
 
 // PERCENTILEOPT returns an optimized PERCENTILE that wraps an existing
-// PERCENTILE and reuses its storage.
+// PERCENTILE.
 func PERCENTILEOPT(wrapped interface{}, percentile interface{}) Expr {
 	var expr Expr
 	switch t := wrapped.(type) {
 	case *ptileOptimized:
-		expr = t.wrapped
+		expr = &t.ptile
 	default:
 		expr = wrapped.(*ptile)
 	}
-	return &ptileOptimized{Wrapped: expr, wrapped: expr.(*ptile), Percentile: exprFor(percentile)}
+	return &ptileOptimized{Wrapped: expr, ptile: *expr.(*ptile), Percentile: exprFor(percentile)}
 }
 
 type ptileOptimized struct {
+	ptile
 	Wrapped    Expr
-	wrapped    *ptile
 	Percentile Expr
 }
 
-func (e *ptileOptimized) Validate() error {
-	return e.wrapped.Validate()
-}
-
-func (e *ptileOptimized) EncodedWidth() int {
-	return 0
-}
-
-func (e *ptileOptimized) Shift() time.Duration {
-	return 0
-}
-
-func (e *ptileOptimized) Update(b []byte, params Params, metadata goexpr.Params) ([]byte, float64, bool) {
-	return b, 0, false
-}
-
-func (e *ptileOptimized) Merge(b []byte, x []byte, y []byte) ([]byte, []byte, []byte) {
-	return b, x, y
-}
-
-func (e *ptileOptimized) SubMergers(subs []Expr) []SubMerge {
-	return nil
-}
-
 func (e *ptileOptimized) Get(b []byte) (float64, bool, []byte) {
-	histo, wasSet, remain := e.wrapped.load(b)
+	histo, wasSet, remain := e.ptile.load(b)
 	percentile, _, remain := e.Percentile.Get(remain)
 	if !wasSet {
 		return 0, wasSet, remain
 	}
-	return e.wrapped.calc(histo, percentile), wasSet, remain
-}
-
-func (e *ptileOptimized) IsConstant() bool {
-	return false
-}
-
-func (e *ptileOptimized) DeAggregate() Expr {
-	return PERCENTILE(e.wrapped.DeAggregate(), e.Percentile.DeAggregate(), scaleFromInt(e.wrapped.Min, e.wrapped.Precision), scaleFromInt(e.wrapped.Max, e.wrapped.Precision), e.wrapped.Precision)
+	return e.ptile.calc(histo, percentile), wasSet, remain
 }
 
 func (e *ptileOptimized) String() string {
-	return fmt.Sprintf("PERCENTILE(%v, %v)", e.wrapped.String(), e.Percentile)
+	return fmt.Sprintf("PERCENTILE(%v, %v)", e.Wrapped.String(), e.Percentile)
 }
 
 func (e *ptileOptimized) DecodeMsgpack(dec *msgpack.Decoder) error {
@@ -81,7 +47,7 @@ func (e *ptileOptimized) DecodeMsgpack(dec *msgpack.Decoder) error {
 	wrapped := m["Wrapped"].(*ptile)
 	percentile := m["Percentile"].(Expr)
 	e.Wrapped = wrapped
-	e.wrapped = wrapped
+	e.ptile = *wrapped
 	e.Percentile = percentile
 	return nil
 }

--- a/expr/percentile_test.go
+++ b/expr/percentile_test.go
@@ -23,7 +23,7 @@ func TestPercentile(t *testing.T) {
 	e := msgpacked(t, PERCENTILE(SUM("a"), 99, 0, 100, 1))
 	expected := float64(99)
 
-	eo := msgpacked(t, PERCENTILE(e, 50, 0, 100, 1))
+	eo := msgpacked(t, PERCENTILEOPT(e, 50))
 	expectedO := float64(51)
 
 	eo2 := msgpacked(t, PERCENTILEOPT(eo, 1))
@@ -58,9 +58,6 @@ func TestPercentile(t *testing.T) {
 			// Do some direct updates
 			for k := float64(1); k <= 50; k++ {
 				e.Update(b, Map{"a": k}, md)
-				// Also update the wrapped expressions to make sure this is a noop
-				eo.Update(b, Map{"a": k}, md)
-				eo2.Update(b, Map{"a": k}, md)
 			}
 
 			// Do some point merges

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -813,6 +813,7 @@ func (f *fielded) percentileExprFor(e *sqlparser.FuncExpr, fname string, default
 	} else {
 		if isOptimized {
 			// tried to wrap a non-percentile expression in a PERCENTILEOPT
+			log.Errorf("Tried to wrap %v of type %v with optimized PERCENTILE", valueField, reflect.TypeOf(valueField.Expr))
 			return nil, ErrPercentileOptWrap
 		}
 		// existing expression is not a percentile, need to get the field


### PR DESCRIPTION
This fix allows queries to use PERCENTILE expressions that wrap existing PERCENTILEs.